### PR TITLE
Fix rewriting and CORS for clients that do not append .view

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -4,13 +4,21 @@ import (
 	"hifi/config"
 	"net/http"
 	"slices"
+	"strings"
 )
 
 // -------------------- CORS --------------------
 
 func CORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if slices.Contains(config.ValidPaths, r.URL.Path) {
+		path := r.URL.Path
+
+		// Ensure path ends with .view (for Tempo)
+		if !strings.HasSuffix(path, ".view") {
+			path += ".view"
+		}
+
+		if slices.Contains(config.ValidPaths, path) {
 			w.Header().Set(config.HeaderAllowOrigin, config.CORSAllowOrigin)
 		}
 		next.ServeHTTP(w, r)

--- a/middleware/rewrite.go
+++ b/middleware/rewrite.go
@@ -4,6 +4,7 @@ import (
 	"hifi/routes/rest"
 	"hifi/types"
 	"net/http"
+	"strings"
 	"sync"
 )
 
@@ -29,7 +30,15 @@ func RewriteRequest(w http.ResponseWriter, r *http.Request) {
 		id     = r.URL.Query().Get("id")
 		size   = r.URL.Query().Get("size")
 	)
-	switch r.URL.Path {
+
+	path := r.URL.Path
+
+	// Ensure path ends with .view (for Tempo)
+	if !strings.HasSuffix(path, ".view") {
+		path += ".view"
+	}
+
+	switch path {
 
 	// -------------------- Search3 --------------------
 	case rest.Search3View():


### PR DESCRIPTION
In my previous PR, I failed to append `.view` internally on all paths, leading to blank pages and lack of CORS headers when requested without `.view`. This PR fixes these issues.