### PR TITLE
Update types.go

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -9,9 +9,9 @@ import (
 func MetaBanner() SubsonicWrapper {
 	var w SubsonicWrapper
 	w.Subsonic.Status = "ok"
-	w.Subsonic.Version = "1.15.0"
+	w.Subsonic.Version = "6.1.4"
 	w.Subsonic.Type = "hifi"
-	w.Subsonic.ServerVersion = "0.19.0"
+	w.Subsonic.ServerVersion = "1.16.1"
 	w.Subsonic.OpenSubsonic = true
 	return w
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updated Subsonic API version numbers in `MetaBanner()` function from 1.15.0 to 6.1.4 and ServerVersion from 0.19.0 to 1.16.1.

**Key Issues:**
- Version inconsistency: `MetaBanner()` now reports different versions (6.1.4 / 1.16.1) than other middleware functions like `writeSubsonic()` and `writeSubsonicv2()` which still use 2.0.0 for both fields
- This could cause Subsonic clients to receive different API versions depending on which endpoint they call
- No context provided in the PR description explaining why these specific version numbers were chosen or what compatibility this change targets

<h3>Confidence Score: 2/5</h3>

- This PR introduces version inconsistency that could cause API compatibility issues
- The change updates version numbers in `MetaBanner()` but creates a critical inconsistency with other parts of the codebase that still report version 2.0.0. Different endpoints will now report different API versions to clients, which violates API contract expectations and could break client compatibility or cause unpredictable behavior.
- `middleware/ping.go` and `middleware/get_user.go` should be reviewed to ensure version consistency across all API responses

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| types/types.go | Updated Subsonic API version from 1.15.0 to 6.1.4 and ServerVersion from 0.19.0 to 1.16.1, but creates version inconsistency with other middleware files |

</details>


</details>


<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->