### PR TITLE
Update ping.go

### DIFF
--- a/middleware/ping.go
+++ b/middleware/ping.go
@@ -10,9 +10,9 @@ import (
 func writeSubsonic(w http.ResponseWriter, status string, code int) {
 	var resp types.SubsonicWrapper
 	resp.Subsonic.Status = status
-	resp.Subsonic.Version = "2.0.0"
+	resp.Subsonic.Version = "6.1.4"
 	resp.Subsonic.Type = "hifi"
-	resp.Subsonic.ServerVersion = "2.0.0"
+	resp.Subsonic.ServerVersion = "1.16.1"
 	resp.Subsonic.OpenSubsonic = true
 
 	b, err := json.Marshal(resp)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updated the Subsonic API version from `2.0.0` to `6.1.4` and server version from `2.0.0` to `1.16.1` in the `writeSubsonic` helper function used by the ping endpoint.

**Key Issues:**
- **Version inconsistency**: This change creates inconsistency across the codebase, as different endpoints now report different API and server versions (`types.go` reports 1.15.0/0.19.0, `get_user.go` reports 2.0.0/2.0.0, and now `ping.go` reports 6.1.4/1.16.1)
- **Counterintuitive versioning**: The server version decreased from 2.0.0 to 1.16.1 while the API version increased from 2.0.0 to 6.1.4, which is unusual

**Recommendation:**
Centralize version constants in a configuration file and ensure all endpoints consistently report the same API and server versions to avoid client confusion.

<h3>Confidence Score: 2/5</h3>

- This PR introduces version inconsistencies that could cause client compatibility issues and confusion
- The change itself is simple (updating two hardcoded version strings), but it creates significant inconsistency across the codebase where different endpoints report different API and server versions. Additionally, the server version decreases while the API version increases, which is counterintuitive and suggests potential confusion about what these version numbers should represent.
- Pay close attention to `middleware/ping.go` and verify the version numbers are intentional, then check `types/types.go` and `middleware/get_user.go` for consistent versioning

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| middleware/ping.go | Updated Subsonic API version from 2.0.0 to 6.1.4 and server version from 2.0.0 to 1.16.1, creating version inconsistencies across the codebase |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->