### PR TITLE
Update get_user.go

### DIFF
--- a/middleware/get_user.go
+++ b/middleware/get_user.go
@@ -11,9 +11,9 @@ import (
 func writeSubsonicv2(w http.ResponseWriter, status string, code int, data map[string]any) {
 	var base types.SubsonicWrapper
 	base.Subsonic.Status = status
-	base.Subsonic.Version = "2.0.0"
+	base.Subsonic.Version = "6.1.4"
 	base.Subsonic.Type = "hifi"
-	base.Subsonic.ServerVersion = "2.0.0"
+	base.Subsonic.ServerVersion = "1.16.1"
 	base.Subsonic.OpenSubsonic = true
 
 	b, err := json.Marshal(base)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updated Subsonic API version numbers in `writeSubsonicv2` function to align with OpenSubsonic standards used throughout the codebase.

- Changed `Version` from "2.0.0" to "6.1.4" (OpenSubsonic API version)
- Changed `ServerVersion` from "2.0.0" to "1.16.1" (Subsonic server compatibility version)

These changes standardize version reporting across all middleware files (`middleware/get_user.go:14`, `middleware/get_user.go:16`, `middleware/ping.go:13`, `middleware/ping.go:15`, and `types/types.go:12-14`), ensuring consistent API compatibility with OpenSubsonic clients like Feishin.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - standardizes version numbers with no functional changes
- This is a low-risk change that simply updates hardcoded version strings to match the values already used in `types/types.go` and `middleware/ping.go`. The changes ensure consistent OpenSubsonic API version reporting across the codebase without altering any logic or behavior.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| middleware/get_user.go | Updated Subsonic API version from 2.0.0 to 6.1.4 and server version from 2.0.0 to 1.16.1 to standardize with other middleware files |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->