### PR TITLE
fix server version ping logic

### DIFF
--- a/middleware/ping.go
+++ b/middleware/ping.go
@@ -10,9 +10,9 @@ import (
 func writeSubsonic(w http.ResponseWriter, status string, code int) {
 	var resp types.SubsonicWrapper
 	resp.Subsonic.Status = status
-	resp.Subsonic.Version = "6.1.4"
+	resp.Subsonic.Version = "1.16.1"
 	resp.Subsonic.Type = "hifi"
-	resp.Subsonic.ServerVersion = "1.16.1"
+	resp.Subsonic.ServerVersion = "6.1.4"
 	resp.Subsonic.OpenSubsonic = true
 
 	b, err := json.Marshal(resp)


### PR DESCRIPTION
Server version and version tag logic is reversed, should be the other way around

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix swapped `version` and `serverVersion` fields in Subsonic ping response
> Corrects a transposition in [middleware/ping.go](https://github.com/sachinsenal0x64/hifi/pull/108/files#diff-40ce39bd66fbf6628c9ae9bce32663b33539e42cf42e22094b42008d034e1219) where `Subsonic.Version` and `Subsonic.ServerVersion` were assigned each other's values. `version` now returns `1.16.1` (the API version) and `serverVersion` returns `6.1.4` (the server version).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59bafa6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes swapped `Version` and `ServerVersion` fields in `middleware/ping.go`, correctly assigning `"1.16.1"` (Subsonic API version) to `Version` and `"6.1.4"` (hifi server version) to `ServerVersion`. However, the same transposed values persist in `types.MetaBanner()` (`types/types.go` lines 12–14), which is used by 7 other middleware handlers, leaving those endpoints still returning the incorrect mapping.

- `types/types.go` `MetaBanner()` still sets `Version = "6.1.4"` and `ServerVersion = "1.16.1"` — the same bug this PR intends to fix — and is called from `song.go`, `search3.go`, `artists.go`, `artist_info.go`, `artist.go`, `album_list2.go`, and `album.go`.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the ping endpoint, but the fix is incomplete — 7 other endpoints remain broken via MetaBanner().

A P1 finding remains: the root-cause function MetaBanner() in types/types.go was not updated, so the majority of API endpoints still return swapped version fields despite this PR's intent to fix that.

types/types.go — MetaBanner() still has Version and ServerVersion swapped

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| middleware/ping.go | Correctly swaps Version ("1.16.1" Subsonic API) and ServerVersion ("6.1.4" hifi server), but the same swap is still needed in types/types.go MetaBanner() which serves 7 other endpoints |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Subsonic Client Request] --> B{Endpoint}
    B -->|/ping| C["writeSubsonic() in ping.go\n✅ Version=1.16.1\n✅ ServerVersion=6.1.4"]
    B -->|/getSong\n/search3\n/getArtists\n/getArtistInfo\n/getArtist\n/getAlbumList2\n/getAlbum| D["types.MetaBanner() in types.go\n❌ Version=6.1.4\n❌ ServerVersion=1.16.1"]
    C --> E[Correct Response]
    D --> F[Incorrect Response - values still swapped]
```

<sub>Reviews (1): Last reviewed commit: ["fix server version ping logic"](https://github.com/sachinsenal0x64/hifi/commit/59bafa65e79953932201c8e33c876494e1ebf0ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28128994)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->